### PR TITLE
fixing creating ModbusRtu instance error

### DIFF
--- a/pylibmodbus/modbus_rtu.py
+++ b/pylibmodbus/modbus_rtu.py
@@ -8,4 +8,4 @@ from .modbus_core import C, ModbusCore
 
 class ModbusRtu(ModbusCore):
     def __init__(self, device="/dev/ttyS0", baud=19200, parity="N", data_bit=8, stop_bit=1):
-        self.ctx = C.modbus_new_rtu(device, baud, parity, data_bit, stop_bit)
+        self.ctx = C.modbus_new_rtu(device.encode(), baud, parity.encode(), data_bit, stop_bit)


### PR DESCRIPTION
Error while creating ModbusRtu instance. 
TypeError: initializer for ctype 'char' must be a bytes of length 1, not str
